### PR TITLE
X-Forwarded-For header can have port number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ module.exports = function(defaultCountryCode){
 	}
 
 	var getCountryCodeMiddleware = function(req, res, next) {
-		var ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
+		var xForwardedFor = (req.headers['x-forwarded-for'] || '').replace(/:\d+$/, '');
+		var ip = xForwardedFor || req.connection.remoteAddress;
 		req.countryCode = getCountryCode(ip)
 		next();
 	}


### PR DESCRIPTION
- Add `.gitignore` file
- Fix the fact that the `X-Forwarded-For` header might have a port number, for which `geoip-lite` would just return null when looking the value up
- Formatting