### PR TITLE
Fix getting ip adress from x-forwarded-for

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,8 +19,15 @@ module.exports = function(defaultCountryCode){
 		return countryCode
 	}
 
+	var getXForwardedFor = function(req) {
+		const ips = (req.headers['x-forwarded-for'] || '').split(',')
+		const ip = ips[0] ? ips[0].trim() : ''
+
+		return ip.replace(/:\d+$/, '')
+	}
+
 	var getCountryCodeMiddleware = function(req, res, next) {
-		var xForwardedFor = (req.headers['x-forwarded-for'] || '').replace(/:\d+$/, '');
+		var xForwardedFor = getXForwardedFor(req);
 		var ip = xForwardedFor || req.connection.remoteAddress;
 		req.countryCode = getCountryCode(ip)
 		next();

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "express-geoip",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9,7 +9,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
-        "lodash": "4.17.11"
+        "lodash": "^4.17.10"
       }
     },
     "balanced-match": {
@@ -22,7 +22,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -46,7 +46,7 @@
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "requires": {
-        "pend": "1.2.0"
+        "pend": "~1.2.0"
       }
     },
     "fs.realpath": {
@@ -59,14 +59,14 @@
       "resolved": "https://registry.npmjs.org/geoip-lite/-/geoip-lite-1.3.4.tgz",
       "integrity": "sha512-U4cdz85E6K/OLVgtOaNkqG6jjpZ8xVT5UcM/+WK51Wpnq8sUweeMiYcSmRhv4cIRgyFwHHKNCcyBDDtHa+7THw==",
       "requires": {
-        "async": "2.6.1",
-        "colors": "1.3.2",
-        "glob": "7.1.3",
-        "iconv-lite": "0.4.24",
-        "ip-address": "5.8.9",
-        "lazy": "1.0.11",
-        "rimraf": "2.6.2",
-        "yauzl": "2.10.0"
+        "async": "^2.1.1",
+        "colors": "^1.1.2",
+        "glob": "^7.1.1",
+        "iconv-lite": "^0.4.13",
+        "ip-address": "^5.8.9",
+        "lazy": "^1.0.11",
+        "rimraf": "^2.5.2",
+        "yauzl": "^2.9.2"
       }
     },
     "glob": {
@@ -74,12 +74,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "iconv-lite": {
@@ -87,7 +87,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "inflight": {
@@ -95,8 +95,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -110,11 +110,11 @@
       "integrity": "sha512-7ay355oMN34iXhET1BmCJVsHjOTSItEEIIpOs38qUC23AIhOy+xIPnkrTuEFjeLMrTJ7m8KMXWgWfy/2Vn9sDw==",
       "requires": {
         "jsbn": "1.1.0",
-        "lodash.find": "4.6.0",
-        "lodash.max": "4.0.1",
-        "lodash.merge": "4.6.1",
-        "lodash.padstart": "4.6.1",
-        "lodash.repeat": "4.1.0",
+        "lodash.find": "^4.6.0",
+        "lodash.max": "^4.0.1",
+        "lodash.merge": "^4.6.0",
+        "lodash.padstart": "^4.6.1",
+        "lodash.repeat": "^4.1.0",
         "sprintf-js": "1.1.0"
       }
     },
@@ -163,7 +163,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "once": {
@@ -171,7 +171,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {
@@ -189,13 +189,19 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "7.1.3"
+        "glob": "^7.0.5"
       }
     },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "simple-mock": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/simple-mock/-/simple-mock-0.8.0.tgz",
+      "integrity": "sha1-ScmiI/pu6o4sT9aUj+gwDNillPM=",
+      "dev": true
     },
     "sprintf-js": {
       "version": "1.1.0",
@@ -212,8 +218,8 @@
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "requires": {
-        "buffer-crc32": "0.2.13",
-        "fd-slicer": "1.1.0"
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "geoip-lite": "^1.3.4"
   },
   "description": "Adds the ISO country code of the request to req.countryCode",
-  "devDependencies": {},
+  "devDependencies": {
+    "simple-mock": "^0.8.0"
+  },
   "directories": {},
   "dist": {
     "shasum": "649031271c021e50810407d67d8cddf108775d5e",

--- a/test/tests.js
+++ b/test/tests.js
@@ -3,6 +3,8 @@
 // http://nodejs.org/docs/latest/api/assert.html
 
 var assert = require('assert')
+var simple = require('simple-mock')
+var geoip = require('geoip-lite')
 
 var log = console.log.bind(console)
 
@@ -11,11 +13,52 @@ var geoIP = require('../index.js')('UK');
 // Known addresses
 var US_IP = '108.60.143.242'
 var AU_IP = '139.130.4.5'
+var HU_IP = '172.68.226.56';
 
-suite('geoips', function(){
-	test('correctly handles US and AU addresses', function(){
+suite('geoips', function () {
+	test('correctly handles US and AU addresses', function () {
 		assert.equal(geoIP.getCountryCode(US_IP), 'US')
 		assert.equal(geoIP.getCountryCode(AU_IP), 'AU')
 	});
 });
 
+suite('middleware', function () {
+	setup(function () {
+		simple.mock(geoip, 'lookup');
+	});
+
+	teardown(function () {
+		simple.restore();
+	});
+
+	test('use ip from x-forwarded-for for lookup', function () {
+		var fakeReq = {
+			headers: {
+				'x-forwarded-for': US_IP,
+			},
+		};
+		geoIP.getCountryCodeMiddleware(fakeReq, {}, simple.stub());
+		assert.equal(geoip.lookup.lastCall.arg, US_IP);
+	});
+	
+	test('use first ip from x-forwarded-for for lookup', function () {
+		var fakeReq = {
+			headers: {
+				'x-forwarded-for': [HU_IP, AU_IP, US_IP].join(', '),
+			},
+		};
+		geoIP.getCountryCodeMiddleware(fakeReq, {}, simple.stub());
+		assert.equal(geoip.lookup.lastCall.arg, HU_IP);
+	});
+
+	test('use connection remote address for lookup when x-forwarded-for is empty', function () {
+		var fakeReq = {
+			headers: {},
+			connection: {
+				remoteAddress: AU_IP,
+			}
+		};
+		geoIP.getCountryCodeMiddleware(fakeReq, {}, simple.stub());
+		assert.equal(geoip.lookup.lastCall.arg, AU_IP);
+	});
+});


### PR DESCRIPTION
Fix case when `x-forwarded-for` headers contains multiple ip adresses. We need to take the first one in that case.